### PR TITLE
Add extra params to encryptPath (cleartextPath, cleartextListFile, outputPath)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You will need Java 9 installed to run it.
 ## Usage
 
 ```
-java -jar sanitizer-0.15.jar command ...
+java -jar sanitizer-0.16.jar command ...
 
 commands:
 * check - check a vault for problems
@@ -25,7 +25,7 @@ A more detailed guide on how to use Sanitizer can be found [here](https://commun
 ### check command usage
 
 ```
-java -jar sanitizer-0.15.jar check -vault vaultPath [-passphraseFile passphraseFile] [-deep] [-solve enabledSolution ...] [-output outputPrefix]
+java -jar sanitizer-0.16.jar check -vault vaultPath [-passphraseFile passphraseFile] [-deep] [-solve enabledSolution ...] [-output outputPrefix]
 
 Detects problems in Cryptomator vaults.
 
@@ -55,7 +55,7 @@ Detects problems in Cryptomator vaults.
 ### decryptFile command usage
 
 ```
-java -jar sanitizer-0.15.jar decryptFile -vault vaultPath [-passphraseFile passphraseFile]
+java -jar sanitizer-0.16.jar decryptFile -vault vaultPath [-passphraseFile passphraseFile]
 
 Decrypts single Cryptomator files.
 
@@ -72,7 +72,7 @@ Decrypts single Cryptomator files.
 ### encryptPath command usage
 
 ```
-java -jar sanitizer-0.15.jar encryptPath -vault vaultPath [-passphraseFile passphraseFile]
+java -jar sanitizer-0.16.jar encryptPath -vault vaultPath [-passphraseFile passphraseFile] [-cleartextPath cleartextPath] [-cleartextListFile cleartextListFile] [-outputPath outputPath]
 
 Encrypt cleartext paths for a Cryptomator vault.
 
@@ -84,12 +84,22 @@ Encrypt cleartext paths for a Cryptomator vault.
                                         this and you will be promted for the
                                         passphrase.
     --vault <vaultPath>                 On which vault to work.
+    --cleartextPath <cleartextPath>     Path of the cleartext file in the
+                                        vault. Omit this and you will be
+                                        prompted for the path.
+    --cleartextListFile <cleartextListFile>
+                                        Path to a line-separated file that
+                                        lists cleartexts in the vault. This
+                                        can be used to substitute for
+                                        cleartextPath.
+    --outputPath <outputPath>           Path of the output file.
+                                        Supported extensions: txt, csv
 ```
 
 ### decryptVault command usage
 
 ```
-java -jar sanitizer-0.15.jar decryptVault -vault vaultPath -target targetPath [-passphraseFile passphraseFile]
+java -jar sanitizer-0.16.jar decryptVault -vault vaultPath -target targetPath [-passphraseFile passphraseFile]
 
 Decrypts all data from a vault and tries to restore inaccessible data.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.cryptomator</groupId>
 	<artifactId>sanitizer</artifactId>
-	<version>0.16-SNAPSHOT</version>
+	<version>0.17-SNAPSHOT</version>
 	<description>Utilities to find and fix problems within vaults</description>
 
 	<properties>

--- a/src/main/java/org/cryptomator/sanitizer/commands/EncryptPathRunner.java
+++ b/src/main/java/org/cryptomator/sanitizer/commands/EncryptPathRunner.java
@@ -18,7 +18,7 @@ class EncryptPathRunner implements Runnable {
 	@Override
 	public void run() {
 		try (Passphrase passphrase = args.passphrase()) {
-			PathEncryptor.encryptPath(args.vaultLocation(), passphrase);
+			PathEncryptor.encryptPath(args.vaultLocation(), passphrase, args.cleartextList(), args.outputPath());
 		} catch (InvalidPassphraseException e) {
 			System.err.println("Invalid passphrase.");
 		} catch (AbortCheckException e) {

--- a/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
+++ b/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
@@ -38,15 +38,15 @@ public class PathEncryptor {
 			paths.put(cleartextPath, null);
 		}
 
-		for (Map.Entry entry : paths.entrySet()){
-            try {
+		for (Map.Entry entry : paths.entrySet()) {
+			try {
 				entry.setValue(resolvePath(vaultLocation, console, cryptor, (String) entry.getKey()));
-            } catch (NoSuchFileException e) {
-            	// entry.value will remain null and will be handled at a later point.
-            }
-        }
+			} catch (NoSuchFileException e) {
+				// entry.value will remain null and will be handled at a later point.
+			}
+		}
 
-        printResolvedPaths(console, paths, outputPath);
+		printResolvedPaths(console, paths, outputPath);
 
 		cryptor.destroy();
 	}
@@ -61,7 +61,7 @@ public class PathEncryptor {
 		}
 	}
 
-    private static void printResolvedPaths(Console console, Map<String, Path> paths, String outputPath) throws IOException {
+	private static void printResolvedPaths(Console console, Map<String, Path> paths, String outputPath) throws IOException {
 		if (outputPath != null) {
 			BufferedWriter writer = new BufferedWriter(new FileWriter(outputPath));
 			String line;
@@ -80,6 +80,6 @@ public class PathEncryptor {
 				console.flush();
 			}
 		}
-    }
+	}
 
 }

--- a/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
+++ b/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
@@ -3,11 +3,11 @@ package org.cryptomator.sanitizer.restorer;
 import static org.cryptomator.sanitizer.CryptorHolder.bestGuessCryptorProvider;
 import static org.cryptomator.sanitizer.CryptorHolder.normalizePassphrase;
 
-import java.io.Console;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.cryptomator.cryptolib.api.Cryptor;
@@ -16,7 +16,7 @@ import org.cryptomator.cryptolib.api.KeyFile;
 
 public class PathEncryptor {
 
-	public static void encryptPath(Path vaultLocation, CharSequence passphrase) throws IOException {
+	public static void encryptPath(Path vaultLocation, CharSequence passphrase, List<String> cleartextList, String outputPath) throws IOException {
 		Console console = System.console();
 		if (console == null) {
 			System.err.println("Couldn't get Console instance");
@@ -28,14 +28,30 @@ public class PathEncryptor {
 		CryptorProvider provider = bestGuessCryptorProvider(keyFile);
 		Cryptor cryptor = provider.createFromKeyFile(keyFile, normalizePassphrase(keyFile, passphrase), keyFile.getVersion());
 
-		Path filePath = resolvePath(vaultLocation, console, cryptor);
-		console.printf("Resolved: %s\n", filePath);
+		Map<String,Path> paths = new HashMap<>();
+		if (cleartextList != null) {
+			for (String path : cleartextList) {
+				paths.put(path, null);
+			}
+		} else {
+			String cleartextPath = StringUtils.removeStart(console.readLine("Enter a (cleartext) path of a file inside the vault: "), "/");
+			paths.put(cleartextPath, null);
+		}
+
+		for (Map.Entry entry : paths.entrySet()){
+            try {
+				entry.setValue(resolvePath(vaultLocation, console, cryptor, (String) entry.getKey()));
+            } catch (NoSuchFileException e) {
+            	// entry.value will remain null and will be handled at a later point.
+            }
+        }
+
+        printResolvedPaths(console, paths, outputPath);
 
 		cryptor.destroy();
 	}
 
-	private static Path resolvePath(Path vaultRoot, Console console, Cryptor cryptor) throws NoSuchFileException {
-		String cleartextPath = StringUtils.removeStart(console.readLine("Enter a (cleartext) path of a file inside the vault: "), "/");
+	private static Path resolvePath(Path vaultRoot, Console console, Cryptor cryptor, String cleartextPath) throws NoSuchFileException {
 		String ciphertextPath = new CiphertextPathBuilder(vaultRoot, console, cryptor).resolve(cleartextPath);
 		Path result = vaultRoot.resolve(ciphertextPath);
 		if (Files.isRegularFile(result)) {
@@ -44,5 +60,26 @@ public class PathEncryptor {
 			throw new NoSuchFileException(result.toString());
 		}
 	}
+
+    private static void printResolvedPaths(Console console, Map<String, Path> paths, String outputPath) throws IOException {
+		if (outputPath != null) {
+			BufferedWriter writer = new BufferedWriter(new FileWriter(outputPath));
+			String line;
+			for (Map.Entry entry : paths.entrySet()) {
+				if (outputPath.endsWith(".csv")) {
+					line = String.format("\"%s\",\"%s\"", entry.getKey(), entry.getValue());
+				} else {
+					line = String.format("%s: %s", entry.getKey(), entry.getValue());
+				}
+				writer.write(line + "\n");
+			}
+			writer.close();
+		} else {
+			for (Map.Entry entry : paths.entrySet()) {
+				console.printf("%s: %s\n", entry.getValue());
+				console.flush();
+			}
+		}
+    }
 
 }

--- a/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
+++ b/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
@@ -63,17 +63,17 @@ public class PathEncryptor {
 
 	private static void printResolvedPaths(Console console, Map<String, Path> paths, String outputPath) throws IOException {
 		if (outputPath != null) {
-			BufferedWriter writer = new BufferedWriter(new FileWriter(outputPath));
-			String line;
-			for (Map.Entry entry : paths.entrySet()) {
-				if (outputPath.endsWith(".csv")) {
-					line = String.format("\"%s\",\"%s\"", entry.getKey(), entry.getValue());
-				} else {
-					line = String.format("%s: %s", entry.getKey(), entry.getValue());
+			try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputPath))) {
+				String line;
+				for (Map.Entry entry : paths.entrySet()) {
+					if (outputPath.endsWith(".csv")) {
+						line = String.format("\"%s\",\"%s\"", entry.getKey(), entry.getValue());
+					} else {
+						line = String.format("%s: %s", entry.getKey(), entry.getValue());
+					}
+					writer.write(line + "\n");
 				}
-				writer.write(line + "\n");
 			}
-			writer.close();
 		} else {
 			for (Map.Entry entry : paths.entrySet()) {
 				console.printf("%s: %s\n", entry.getValue());

--- a/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
+++ b/src/main/java/org/cryptomator/sanitizer/restorer/PathEncryptor.java
@@ -76,7 +76,7 @@ public class PathEncryptor {
 			}
 		} else {
 			for (Map.Entry entry : paths.entrySet()) {
-				console.printf("%s: %s\n", entry.getValue());
+				console.printf("%s: %s\n", entry.getKey(), entry.getValue());
 				console.flush();
 			}
 		}


### PR DESCRIPTION
Hi, I really enjoy using Cryptomator and thought I'd contribute to the project and help the community.

I added three optional parameters to the `encryptPath` command, mainly to support the batch use case.

I was personally evaluating how easy it would be to restore files in a vault (kinda similar to https://community.cryptomator.org/t/file-restore-from-backup-how-to-know-which-file/123) and thought this batch feature would make my life a lot easier.

Now to the technical details....

### cleartextListFile

`cleartextListFile` is a line-separated text file that contains the paths you want to encrypt. Here is a sample:

```
file1-in-vault.jpg
file2-in-vault.txt
```

### outputPath

`outputPath` , If specified, saves the resolved path(s) to a file, rather than printing them directly to the console. This helps when you are processing a large number of paths.

### cleartextPath

`cleartextPath` is a little bonus param which allows you to specify a single path in the command itself. This does the same thing as providing a path during the runtime.

### Other things...

Previously, if you encrypted a path, the output looked like this:
```
Resolved: ${ciphertext_path}
```

Now the new output looks like this:
```
${cleartext_path}: ${ciphertext_path}
```

Lastly, the code has been manually tested on a Mac. Please let me know if there are guidelines as to how the new code should be tested.

Thanks,
Jaeseo